### PR TITLE
Less strict peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-release": "~0.3.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
I just tested this module with grunt@1.0.1 and it works fine, but I get annoying warnings in the console when installing that it doesn't satisfy grunt-clear's peer dependency. There's no reason it can't though.